### PR TITLE
optimize(): zpp segfault fix + parse int macros

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,1 +1,2 @@
 - Fix compile error: libcurl on linux multiarch support (#46)
+- Fix SegFault in SolrClient::optimize() (debug mode)

--- a/NEWS
+++ b/NEWS
@@ -1,1 +1,1 @@
-
+- Fix compile error: libcurl on linux multiarch support (#46)

--- a/src/php7/php_solr_client.c
+++ b/src/php7/php_solr_client.c
@@ -1548,13 +1548,13 @@ end_doc_queries_loop :
 }
 /* }}} */
 
-/* {{{ proto SolrUpdateResponse SolrClient::optimize([string maxSegments [, bool softCommit [, bool waitSearcher]])
+/* {{{ proto SolrUpdateResponse SolrClient::optimize([int maxSegments [, bool softCommit [, bool waitSearcher]])
    Sends an optimize XML request to the server. */
 PHP_METHOD(SolrClient, optimize)
 {
+	SOLR_PARSE_PARAM_INT_DEF(maxSegmentsZval, maxSegments, maxSegmentsLen, "1");
+
 	zend_bool softCommit = 0, waitSearcher = 1;
-	char *maxSegments = "1";
-	int maxSegmentsLen = sizeof("1")-1;
 	char *softCommitValue, *waitSearcherValue;
 	xmlNode *root_node = NULL;
 	xmlDoc *doc_ptr = NULL;
@@ -1564,12 +1564,11 @@ PHP_METHOD(SolrClient, optimize)
 	xmlChar *request_string = NULL;
 	zend_bool success = 1;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|sbb", &maxSegments, &maxSegmentsLen, &softCommit, &waitSearcher) == FAILURE) {
-
-		php_error_docref(NULL, E_WARNING, "Invalid parameter");
-
-		return;
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|zbb", &maxSegmentsZval, &softCommit, &waitSearcher) == FAILURE) {
+		RETURN_THROWS();
 	}
+
+	SOLR_PARSE_PARAM_INT(maxSegmentsZval, maxSegments, maxSegmentsLen, "maxSegments");
 
 	softCommitValue = (softCommit)? "true" : "false";
 	waitSearcherValue = (waitSearcher)? "true" : "false";

--- a/src/php7/php_solr_client.c
+++ b/src/php7/php_solr_client.c
@@ -1548,7 +1548,7 @@ end_doc_queries_loop :
 }
 /* }}} */
 
-/* {{{ proto SolrUpdateResponse SolrClient::optimize([int maxSegments [, bool softCommit [, bool waitSearcher]])
+/* {{{ proto SolrUpdateResponse SolrClient::optimize([string maxSegments [, bool softCommit [, bool waitSearcher]])
    Sends an optimize XML request to the server. */
 PHP_METHOD(SolrClient, optimize)
 {

--- a/src/php7/php_solr_client.c
+++ b/src/php7/php_solr_client.c
@@ -1548,11 +1548,11 @@ end_doc_queries_loop :
 }
 /* }}} */
 
-/* {{{ proto SolrUpdateResponse SolrClient::optimize([int maxSegments [, bool softCommit [, bool waitSearcher]])
+/* {{{ proto SolrUpdateResponse SolrClient::optimize([string maxSegments [, bool softCommit [, bool waitSearcher]])
    Sends an optimize XML request to the server. */
 PHP_METHOD(SolrClient, optimize)
 {
-	SOLR_PARSE_PARAM_INT_DEF(maxSegmentsZval, maxSegments, maxSegmentsLen, "1");
+	SOLR_DEFINE_PARSE_PARAM_INT(maxSegmentsZval, maxSegments, maxSegmentsLen, "1");
 
 	zend_bool softCommit = 0, waitSearcher = 1;
 	char *softCommitValue, *waitSearcherValue;

--- a/src/php7/php_solr_client.c
+++ b/src/php7/php_solr_client.c
@@ -1548,7 +1548,7 @@ end_doc_queries_loop :
 }
 /* }}} */
 
-/* {{{ proto SolrUpdateResponse SolrClient::optimize([string maxSegments [, bool softCommit [, bool waitSearcher]])
+/* {{{ proto SolrUpdateResponse SolrClient::optimize([int maxSegments [, bool softCommit [, bool waitSearcher]])
    Sends an optimize XML request to the server. */
 PHP_METHOD(SolrClient, optimize)
 {

--- a/src/php7/solr_functions_helpers.c
+++ b/src/php7/solr_functions_helpers.c
@@ -306,47 +306,22 @@ PHP_SOLR_API void solr_destroy_function(zval *solr_function)
 /* {{{ PHP_SOLR_API xmlDocPtr solr_xml_create_xml_doc(const xmlChar *root_node_name, xmlNode **root_node_ptr) */
 PHP_SOLR_API xmlDocPtr solr_xml_create_xml_doc(const xmlChar *root_node_name, xmlNode **root_node_ptr)
 {
-    if (!root_node_name) {
-        php_error_docref(NULL, E_WARNING, "Error: root_node_name is NULL.");
-        return NULL;
-    }
+	xmlNs *ns = NULL;
 
-    xmlNs *ns = NULL;
+	xmlDoc *doc_ptr = xmlNewDoc((xmlChar *) "1.0");
 
-    xmlDoc *doc_ptr = xmlNewDoc((xmlChar *) "1.0");
-    if (!doc_ptr) {
-        // Handle the error using php_error_docref
-        php_error_docref(NULL, E_WARNING, "Error: Failed to create a new XML document.");
-        return NULL;
-    }
+	xmlNode *root_node = xmlNewNode(ns, root_node_name);
 
-    doc_ptr->encoding = xmlStrdup((const xmlChar *)"UTF-8");
-    if (!doc_ptr->encoding) {
-        // Handle the error using php_error_docref
-        php_error_docref(NULL, E_WARNING, "Error: Failed to set encoding for the XML document.");
-        xmlFreeDoc(doc_ptr);
-        return NULL;
-    }
+	xmlDocSetRootElement(doc_ptr, root_node);
 
-    xmlNode *root_node = xmlNewNode(ns, root_node_name);
-    if (!root_node) {
-        // Handle the error using php_error_docref
-        php_error_docref(NULL, E_WARNING, "Error: Failed to create a new XML node.");
-        xmlFreeDoc(doc_ptr);
-        return NULL;
-    }
+	if (root_node_ptr)
+	{
+		*root_node_ptr = root_node;
+	}
 
-    xmlDocSetRootElement(doc_ptr, root_node);
-
-    if (root_node_ptr) {
-        *root_node_ptr = root_node;
-    }
-
-    return doc_ptr;
+	return doc_ptr;
 }
 /* }}} */
-
-
 
 /**
  * escapes strings with characters that are part of the Lucene query syntax

--- a/src/php7/solr_functions_helpers.c
+++ b/src/php7/solr_functions_helpers.c
@@ -306,22 +306,47 @@ PHP_SOLR_API void solr_destroy_function(zval *solr_function)
 /* {{{ PHP_SOLR_API xmlDocPtr solr_xml_create_xml_doc(const xmlChar *root_node_name, xmlNode **root_node_ptr) */
 PHP_SOLR_API xmlDocPtr solr_xml_create_xml_doc(const xmlChar *root_node_name, xmlNode **root_node_ptr)
 {
-	xmlNs *ns = NULL;
+    if (!root_node_name) {
+        php_error_docref(NULL, E_WARNING, "Error: root_node_name is NULL.");
+        return NULL;
+    }
 
-	xmlDoc *doc_ptr = xmlNewDoc((xmlChar *) "1.0");
+    xmlNs *ns = NULL;
 
-	xmlNode *root_node = xmlNewNode(ns, root_node_name);
+    xmlDoc *doc_ptr = xmlNewDoc((xmlChar *) "1.0");
+    if (!doc_ptr) {
+        // Handle the error using php_error_docref
+        php_error_docref(NULL, E_WARNING, "Error: Failed to create a new XML document.");
+        return NULL;
+    }
 
-	xmlDocSetRootElement(doc_ptr, root_node);
+    doc_ptr->encoding = xmlStrdup((const xmlChar *)"UTF-8");
+    if (!doc_ptr->encoding) {
+        // Handle the error using php_error_docref
+        php_error_docref(NULL, E_WARNING, "Error: Failed to set encoding for the XML document.");
+        xmlFreeDoc(doc_ptr);
+        return NULL;
+    }
 
-	if (root_node_ptr)
-	{
-		*root_node_ptr = root_node;
-	}
+    xmlNode *root_node = xmlNewNode(ns, root_node_name);
+    if (!root_node) {
+        // Handle the error using php_error_docref
+        php_error_docref(NULL, E_WARNING, "Error: Failed to create a new XML node.");
+        xmlFreeDoc(doc_ptr);
+        return NULL;
+    }
 
-	return doc_ptr;
+    xmlDocSetRootElement(doc_ptr, root_node);
+
+    if (root_node_ptr) {
+        *root_node_ptr = root_node;
+    }
+
+    return doc_ptr;
 }
 /* }}} */
+
+
 
 /**
  * escapes strings with characters that are part of the Lucene query syntax

--- a/src/php7/solr_macros.h
+++ b/src/php7/solr_macros.h
@@ -180,7 +180,7 @@ static inline solr_ustream_t *solr_get_ustream_object(zend_object *obj)
  *		}
  *		SOLR_PARSE_PARAM_INT(maxSegmentsZval, maxSegments, maxSegmentsLen, "maxSegments");
  */
-#define SOLR_PARSE_PARAM_INT_DEF(zval_ptr, solrparam, solrparam_len, default_value) \
+#define SOLR_DEFINE_PARSE_PARAM_INT(zval_ptr, solrparam, solrparam_len, default_value) \
     zval *zval_ptr = NULL; \
     char *solrparam = default_value; \
     int solrparam_len = sizeof(default_value)-1;
@@ -195,12 +195,13 @@ static inline solr_ustream_t *solr_get_ustream_object(zend_object *obj)
         } \
         bool is_strict = ZEND_ARG_USES_STRICT_TYPES(); \
         bool is_int = Z_TYPE_P(zval_ptr) == IS_LONG, is_str = Z_TYPE_P(zval_ptr) == IS_STRING; \
-        zend_uchar test = zval_get_type(zval_ptr); \
         bool strict_on_and_not_int = is_strict && Z_TYPE_P(zval_ptr) != IS_LONG; \
-        if (strict_on_and_not_int) { \
+        /* strict mode check, skipped to avoid BC Break */ \
+		/* if (is_strict && !is_int) { \
             solr_throw_exception_ex(solr_ce_SolrIllegalArgumentException, SOLR_ERROR_4000, SOLR_FILE_LINE_FUNC, "%s must be of type int.", param_name); \
             RETURN_NULL(); \
-        } else if (is_int) { \
+        } else */ \
+		if (is_int) { \
             convert_to_string(zval_ptr); \
             is_str = Z_TYPE_P(zval_ptr) == IS_STRING; \
         } \

--- a/src/php7/solr_macros.h
+++ b/src/php7/solr_macros.h
@@ -195,7 +195,6 @@ static inline solr_ustream_t *solr_get_ustream_object(zend_object *obj)
         } \
         bool is_strict = ZEND_ARG_USES_STRICT_TYPES(); \
         bool is_int = Z_TYPE_P(zval_ptr) == IS_LONG, is_str = Z_TYPE_P(zval_ptr) == IS_STRING; \
-        bool strict_on_and_not_int = is_strict && Z_TYPE_P(zval_ptr) != IS_LONG; \
         /* strict mode check, skipped to avoid BC Break */ \
 		/* if (is_strict && !is_int) { \
             solr_throw_exception_ex(solr_ce_SolrIllegalArgumentException, SOLR_ERROR_4000, SOLR_FILE_LINE_FUNC, "%s must be of type int.", param_name); \

--- a/tests/000.solr_int_arg.phpt
+++ b/tests/000.solr_int_arg.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Solr - Accept int (non-strict mode)
+--FILE--
+<?php
+require_once "bootstrap.inc";
+
+$options = array
+(
+    'hostname' => SOLR_SERVER_HOSTNAME,
+    'login'    => SOLR_SERVER_USERNAME,
+    'password' => SOLR_SERVER_PASSWORD,
+    'port'     => SOLR_SERVER_PORT,
+	'path'	   => SOLR_SERVER_PATH
+);
+
+case_title(1, 'No arguments passed');
+$client = new SolrClient($options);
+$updateResponse = $client->optimize();
+print $updateResponse->getRawRequest();
+
+case_title(2, 'int argument passed');
+$updateResponse = $client->optimize(4, true, false);
+print $updateResponse->getRawRequest();
+
+case_title(3, 'string argument passed');
+$updateResponse = $client->optimize('5', true, false);
+print $updateResponse->getRawRequest();
+
+case_title(4, 'object argument passed');
+try {
+	$updateResponse = $client->optimize(new StdClass());
+} catch (SolrIllegalArgumentException $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+--EXPECTF--
+
+case #1: No arguments passed
+<?xml version="1.0" encoding="UTF-8"?>
+<optimize maxSegments="1" softCommit="false" waitSearcher="true"/>
+
+case #2: int argument passed
+<?xml version="1.0" encoding="UTF-8"?>
+<optimize maxSegments="4" softCommit="true" waitSearcher="false"/>
+
+case #3: string argument passed
+<?xml version="1.0" encoding="UTF-8"?>
+<optimize maxSegments="5" softCommit="true" waitSearcher="false"/>
+
+case #4: object argument passed
+maxSegments must be of type int.

--- a/tests/000.solr_int_arg_strict.phpt
+++ b/tests/000.solr_int_arg_strict.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Solr - Accept int (strict mode)
+--FILE--
+<?php
+declare(strict_types=1);
+require_once "bootstrap.inc";
+
+$options = array
+(
+    'hostname' => SOLR_SERVER_HOSTNAME,
+    'login'    => SOLR_SERVER_USERNAME,
+    'password' => SOLR_SERVER_PASSWORD,
+    'port'     => SOLR_SERVER_PORT,
+	'path'	   => SOLR_SERVER_PATH
+);
+$client = new SolrClient($options);
+
+case_title(1, 'No arguments passed');
+$updateResponse = $client->optimize();
+print $updateResponse->getRawRequest();
+
+case_title(2, 'int argument passed');
+$updateResponse = $client->optimize(4, true, false);
+print $updateResponse->getRawRequest();
+
+case_title(3, 'string argument passed');
+try {
+	$updateResponse = $client->optimize('5', true, false);
+} catch (SolrIllegalArgumentException $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+
+case_title(4, 'object argument passed');
+try {
+	$updateResponse = $client->optimize(new StdClass());
+} catch (SolrIllegalArgumentException $e) {
+	echo $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECTF--
+
+case #1: No arguments passed
+<?xml version="1.0" encoding="UTF-8"?>
+<optimize maxSegments="1" softCommit="false" waitSearcher="true"/>
+
+case #2: int argument passed
+<?xml version="1.0" encoding="UTF-8"?>
+<optimize maxSegments="4" softCommit="true" waitSearcher="false"/>
+
+case #3: string argument passed
+maxSegments must be of type int.
+
+case #4: object argument passed
+maxSegments must be of type int.

--- a/tests/000.solr_int_arg_strict.phpt
+++ b/tests/000.solr_int_arg_strict.phpt
@@ -48,7 +48,6 @@ case #2: int argument passed
 <optimize maxSegments="4" softCommit="true" waitSearcher="false"/>
 
 case #3: string argument passed
-maxSegments must be of type int.
 
 case #4: object argument passed
 maxSegments must be of type int.

--- a/tests/009.solrclient_optimize.phpt
+++ b/tests/009.solrclient_optimize.phpt
@@ -6,7 +6,6 @@ include 'skip.if.server_not_configured.inc';
 ?>
 --FILE--
 <?php
-
 require_once "bootstrap.inc";
 
 $options = array
@@ -23,9 +22,13 @@ $updateResponse = $client->optimize();
 print $updateResponse->getRawRequest();
 $updateResponse = $client->optimize(4,true,false);
 print $updateResponse->getRawRequest();
+$updateResponse = $client->optimize('5',true,false);
+print $updateResponse->getRawRequest();
 ?>
 --EXPECTF--
 <?xml version="1.0" encoding="UTF-8"?>
 <optimize maxSegments="1" softCommit="false" waitSearcher="true"/>
 <?xml version="1.0" encoding="UTF-8"?>
 <optimize maxSegments="4" softCommit="true" waitSearcher="false"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<optimize maxSegments="5" softCommit="true" waitSearcher="false"/>

--- a/tests/019.solrclient_getdebug.phpt
+++ b/tests/019.solrclient_getdebug.phpt
@@ -49,7 +49,7 @@ foreach ( $lines as $line) {
 Accept-Charset: utf-8
 Accept: */*
 Authorization: Basic %s
-Connected to %s (%s) port %s (#0)
+Connected to %s
 Connection #0 to host %s left intact
 Connection: keep-alive
 Content-Length: 0

--- a/tests/bootstrap.inc
+++ b/tests/bootstrap.inc
@@ -9,3 +9,14 @@ function separator($label) {
 function print_exception(SolrException $e) {
 	echo sprintf("%s %d: %s", get_class($e), $e->getCode(), $e->getMessage()). PHP_EOL;
 }
+
+/**
+ * Prints a test case title
+ * 
+ * @param int $case_id
+ * @param string $title
+ */
+function case_title(int $case_id, string $title) {
+	$caseTemplate = PHP_EOL . "case #%d: %s" . PHP_EOL;
+	echo sprintf($caseTemplate, $case_id, $title);
+}


### PR DESCRIPTION
```bash
gdb php
gdb >> run -d extension="/home/xxxxx/solr/modules/solr.so" /home/xxxxx/solr/tests/009.solrclient_optimize.php
```

```bash
php --version
PHP 8.2.12-dev (cli) (built: Oct  7 2023 14:55:24) (NTS DEBUG)
Copyright (c) The PHP Group
Zend Engine v4.2.12-dev, Copyright (c) Zend Technologies
```